### PR TITLE
Update mudlet_accessibility_on.lua

### DIFF
--- a/src/aliases/mudlet_accessibility_on.lua
+++ b/src/aliases/mudlet_accessibility_on.lua
@@ -5,6 +5,8 @@ setConfig("autoClearInputLine", true)
 echo("Text will now be removed from the input line after it was sent ✓\n")
 setConfig("showSentText", false)
 echo("Text sent to the game will not appear in the main window ✓\n")
+setConfig("advertiseScreenReader", true)
+echo("Advertising screen reader use to games supporting Mud Terminal Type Standard (MTTS) ✓\n")
 
 setConfig("caretShortcut", "ctrltab")
 echo("Shortcut to switch between input line and main window set to Ctrl+Tab. You can also change it to either Tab or F6 in settings.\n")


### PR DESCRIPTION
Aligned with Mudlet PR #7036, toggling on advertising screen reader usage for games that negotiate the Mud Terminal Type Standard (MTTS).