### PR TITLE
Add: Disable code editor autocomplete 

### DIFF
--- a/src/aliases/mudlet_accessibility_on.lua
+++ b/src/aliases/mudlet_accessibility_on.lua
@@ -7,6 +7,8 @@ setConfig("showSentText", false)
 echo("Text sent to the game will not appear in the main window ✓\n")
 setConfig("advertiseScreenReader", true)
 echo("Advertising screen reader use to games supporting Mud Terminal Type Standard (MTTS) ✓\n")
+setConfig("editorAutoComplete", true)
+echo("Disabling visual auto complete in the code editor ✓\n")
 
 setConfig("caretShortcut", "ctrltab")
 echo("Shortcut to switch between input line and main window set to Ctrl+Tab. You can also change it to either Tab or F6 in settings.\n")


### PR DESCRIPTION
#### Brief overview of PR changes/additions

This PR updates the accessibility alias script to disable the code editor's autocomplete feature when the user runs the "mudlet access on" command. This is achieved by setting `setConfig("editorAutoComplete", false)`, which will be supported in an upcoming Mudlet release.

#### Motivation for adding to Mudlet

Disabling autocomplete in the code editor improves the experience for visually impaired users, as discussed in [Mudlet issue #7782](https://github.com/Mudlet/Mudlet/issues/7782). This change makes it easier for screen reader users to work in the Mudlet editor without distraction from autocomplete popups.

#### Other info (issues closed, discussion etc)

- Implements part of [Mudlet issue #7782](https://github.com/Mudlet/Mudlet/issues/7782)
- Requires a corresponding Mudlet PR to support the `editorAutoComplete` config option.